### PR TITLE
Improve mobile stair profile view and PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,13 +39,18 @@
   .badge{display:inline-flex;gap:6px;align-items:center;padding:4px 8px;border-radius:999px;font-size:.78rem;background:#111623;border:1px solid #243049;color:var(--muted)}
   .badge.ok{color:#b8f7c9;border-color:#1d5432;background:#0b1a11}
   .badge.bad{color:#ffd6d6;border-color:#4b1d27;background:#1a0c10}
-  .canvas-wrap{display:grid;gap:8px;padding:10px 12px 14px}
+  .canvas-wrap{display:grid;gap:10px;padding:10px 12px 14px}
   .toolbar{display:flex;flex-wrap:wrap;gap:8px;align-items:center;justify-content:space-between;padding:0 4px}
   .btn{border:1px solid #2a3140;background:#0e121a;color:var(--ink);padding:8px 10px;border-radius:8px;font-size:.9rem;cursor:pointer}
   .btn:active{transform:translateY(1px)}
-  canvas{width:100%;height:auto;display:block;background:radial-gradient(1200px 400px at 10% 0%,#0f1420 0,#0a0d14 60%,#0a0d14 100%);border-radius:10px;border:1px solid #1f2431}
-  .legend{display:flex;gap:12px;flex-wrap:wrap;font-size:.82rem;color:#9aa6b2;padding:0 4px}
-  .legend span{display:inline-flex;gap:6px;align-items:center}
+  .blueprint{position:relative;border-radius:12px;border:1px solid #1f2431;background:radial-gradient(1200px 400px at 10% 0%,#0f1420 0,#0a0d14 60%,#0a0d14 100%);overflow:hidden;box-shadow:inset 0 0 0 1px rgba(95,179,255,.08)}
+  canvas{width:100%;height:auto;display:block;touch-action:none;cursor:grab}
+  canvas:active{cursor:grabbing}
+  .blueprint-overlay{position:absolute;top:12px;left:12px;right:12px;display:flex;flex-wrap:wrap;gap:8px;pointer-events:none}
+  .blueprint-chip{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;font-size:.75rem;color:#dce9ff;background:rgba(13,18,30,.72);border:1px solid rgba(95,179,255,.28);backdrop-filter:blur(6px);text-transform:uppercase;letter-spacing:.04em}
+  .blueprint-chip.scale{margin-left:auto}
+  .legend{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;font-size:.82rem;color:#9aa6b2;padding:2px 4px 0}
+  .legend span{display:flex;align-items:center;gap:6px;background:#0e121a;border:1px solid #202736;border-radius:8px;padding:6px 8px}
   .swatch{width:14px;height:4px;border-radius:2px;display:inline-block;background:var(--accent)}
   .swatch.run{background:#7cd67c}.swatch.rise{background:#ff9c9c}.swatch.square{background:#ffd36e}.swatch.stringer{background:#8ad}.swatch.dim{background:#c3d4ff}
   details{background:#0e121a;border:1px solid #2a3140;border-radius:10px;padding:10px 12px}
@@ -56,6 +61,10 @@
   th,td{padding:6px 8px;border-bottom:1px solid #1f2431;text-align:right}
   th{text-align:right;color:#cfe3ff;position:sticky;top:0;background:#121828}
   td:first-child,th:first-child{text-align:left}
+  @media(max-width:600px){
+    .blueprint-overlay{flex-direction:column;align-items:flex-start}
+    .blueprint-chip.scale{margin-left:0}
+  }
 </style>
 </head>
 <body>
@@ -131,7 +140,14 @@
         </div>
       </div>
 
-      <canvas id="stairCanvas" width="1400" height="700" aria-label="Stair profile drawing"></canvas>
+      <div class="blueprint" id="blueprintSurface">
+        <canvas id="stairCanvas" width="1400" height="700" aria-label="Stair profile drawing"></canvas>
+        <div class="blueprint-overlay" aria-hidden="true">
+          <span class="blueprint-chip">Drag to pan</span>
+          <span class="blueprint-chip">Pinch or scroll to zoom</span>
+          <span class="blueprint-chip scale" id="scaleBadge">Scale —</span>
+        </div>
+      </div>
 
       <div class="legend">
         <span><i class="swatch stringer"></i> Stringer line</span>
@@ -197,12 +213,14 @@ const el = {
   metrics: document.getElementById('metrics'),
   ircRiser: document.getElementById('ircRiser'),
   ircTread: document.getElementById('ircTread'),
+  blueprint: document.getElementById('blueprintSurface'),
   canvas: document.getElementById('stairCanvas'),
   fitBtn: document.getElementById('fitBtn'),
   resetBtn: document.getElementById('resetBtn'),
   pdfBtn: document.getElementById('pdfBtn'),
   cutsOffsets: document.getElementById('cutsOffsets'),
-  cutTableBody: document.getElementById('cutTable').querySelector('tbody')
+  cutTableBody: document.getElementById('cutTable').querySelector('tbody'),
+  scaleBadge: document.getElementById('scaleBadge')
 };
 const ctx = el.canvas.getContext('2d');
 
@@ -210,10 +228,72 @@ const ctx = el.canvas.getContext('2d');
 let state = {
   input: {...DEFAULTS},
   calc: null,
-  view: { paddingIn:8, scalePxPerIn:4, ox:60, oy: el.canvas.height - 40 }
+  view: {
+    paddingIn:8,
+    baseScale:1,
+    scalePxPerIn:4,
+    zoom:1,
+    minZoom:0.35,
+    maxZoom:8,
+    panX:0,
+    panY:0,
+    autoFit:true,
+    ox:60,
+    oy:el.canvas.height - 40,
+    baseOx:60,
+    baseOy:el.canvas.height - 40,
+    cssWidth:el.canvas.clientWidth || el.canvas.width,
+    cssHeight:el.canvas.clientHeight || el.canvas.height,
+    dpr:window.devicePixelRatio || 1
+  }
 };
 const clamp=(v,min,max)=>Math.max(min,Math.min(max,v));
 function debounce(fn,ms=80){ let t; return (...a)=>{clearTimeout(t); t=setTimeout(()=>fn(...a),ms);} }
+
+function updateOrigin(){
+  state.view.ox = state.view.baseOx + state.view.panX;
+  state.view.oy = state.view.baseOy + state.view.panY;
+}
+
+function updateScaleBadge(){
+  if(!el.scaleBadge) return;
+  if(!state.calc){
+    el.scaleBadge.textContent = 'Scale —';
+    return;
+  }
+  const px = state.view.scalePxPerIn;
+  const display = px >= 100 ? Math.round(px) : Math.round(px*10)/10;
+  el.scaleBadge.textContent = `Scale 1\" ≈ ${display}px`;
+}
+
+function resizeCanvas(){
+  const dpr = window.devicePixelRatio || 1;
+  const rect = el.blueprint.getBoundingClientRect();
+  let width = Math.round(rect.width);
+  if(!width){ width = Math.round(el.canvas.clientWidth || 640); }
+  const height = Math.max(260, Math.round(width * 0.6));
+  el.canvas.style.height = `${height}px`;
+  const displayWidth = Math.floor(width * dpr);
+  const displayHeight = Math.floor(height * dpr);
+  if(el.canvas.width !== displayWidth || el.canvas.height !== displayHeight){
+    el.canvas.width = displayWidth;
+    el.canvas.height = displayHeight;
+  }
+  state.view.cssWidth = width;
+  state.view.cssHeight = height;
+  state.view.dpr = dpr;
+  ctx.setTransform(dpr,0,0,dpr,0,0);
+}
+
+const handleResize = debounce(()=>{
+  resizeCanvas();
+  if(state.calc){
+    computeScale(state.calc);
+    drawStair(state.calc);
+  } else {
+    updateScaleBadge();
+  }
+}, 120);
 
 /* Render */
 function ircBadges(c){
@@ -265,18 +345,85 @@ function computeScale(c){
   const pad=state.view.paddingIn;
   const wIn=c.totalRunCutIn + c.nosingIn*c.treads + 2*pad + 6;
   const hIn=c.effectiveRiseIn + 2*pad + 16;
-  const sx=(el.canvas.width-80)/Math.max(wIn, 1);
-  const sy=(el.canvas.height-80)/Math.max(hIn, 1);
-  state.view.scalePxPerIn = Math.max(2, Math.min(sx, sy));
-  state.view.ox=60; state.view.oy=el.canvas.height-40;
+  const marginLeft = Math.max(40, state.view.cssWidth * 0.08);
+  const marginRight = Math.max(28, state.view.cssWidth * 0.04);
+  const marginTop = Math.max(32, state.view.cssHeight * 0.08);
+  const marginBottom = Math.max(56, state.view.cssHeight * 0.18);
+  const availWidth = Math.max(80, state.view.cssWidth - marginLeft - marginRight);
+  const availHeight = Math.max(80, state.view.cssHeight - marginTop - marginBottom);
+  const sx=availWidth/Math.max(wIn, 1);
+  const sy=availHeight/Math.max(hIn, 1);
+  state.view.baseScale = Math.max(2, Math.min(sx, sy));
+  state.view.baseOx = marginLeft;
+  state.view.baseOy = state.view.cssHeight - marginBottom;
+  if(state.view.autoFit){
+    state.view.zoom = 1;
+    state.view.panX = 0;
+    state.view.panY = 0;
+  }
+  const scaled = state.view.baseScale * state.view.zoom;
+  state.view.scalePxPerIn = Math.max(1, scaled);
+  updateOrigin();
 }
 function toPx(xIn,yIn){ const s=state.view.scalePxPerIn; return [state.view.ox + xIn*s, state.view.oy - yIn*s]; }
-function clearCanvas(){ ctx.clearRect(0,0,el.canvas.width,el.canvas.height); drawGrid(); }
+function screenToInches(xPx,yPx){ const s=state.view.scalePxPerIn; return [(xPx - state.view.ox)/s, (state.view.oy - yPx)/s]; }
+function clearCanvas(){
+  ctx.setTransform(1,0,0,1,0,0);
+  ctx.clearRect(0,0,el.canvas.width,el.canvas.height);
+  ctx.setTransform(state.view.dpr,0,0,state.view.dpr,0,0);
+}
 function drawGrid(){
-  const s=state.view.scalePxPerIn, step=s;
-  ctx.save(); ctx.strokeStyle=getComputedStyle(document.documentElement).getPropertyValue('--grid'); ctx.lineWidth=1;
-  for(let x = state.view.ox - step*100; x < el.canvas.width; x+=step){ ctx.beginPath(); ctx.moveTo(x,8); ctx.lineTo(x,el.canvas.height-8); ctx.stroke(); }
-  for(let y = state.view.oy + step*100; y > 0; y-=step){ ctx.beginPath(); ctx.moveTo(8,y); ctx.lineTo(el.canvas.width-8,y); ctx.stroke(); }
+  const s=state.view.scalePxPerIn;
+  if(!Number.isFinite(s) || s <= 0) return;
+  const cssW = state.view.cssWidth;
+  const cssH = state.view.cssHeight;
+  const style = getComputedStyle(document.documentElement);
+  const minor = style.getPropertyValue('--grid').trim() || '#2a2f3a';
+  const leftIn = (0 - state.view.ox)/s;
+  const rightIn = (cssW - state.view.ox)/s;
+  const bottomIn = (state.view.oy - cssH)/s;
+  const topIn = state.view.oy/s;
+  const startX = Math.floor(leftIn) - 1;
+  const endX = Math.ceil(rightIn) + 1;
+  const startY = Math.floor(bottomIn) - 1;
+  const endY = Math.ceil(topIn) + 1;
+  ctx.save();
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = minor;
+  ctx.globalAlpha = 0.65;
+  for(let i=startX;i<=endX;i+=1){
+    const [x] = toPx(i,0);
+    ctx.beginPath();
+    ctx.moveTo(x,0);
+    ctx.lineTo(x,cssH);
+    ctx.stroke();
+  }
+  for(let j=startY;j<=endY;j+=1){
+    const [,y] = toPx(0,j);
+    ctx.beginPath();
+    ctx.moveTo(0,y);
+    ctx.lineTo(cssW,y);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 0.9;
+  ctx.lineWidth = 1.6;
+  ctx.strokeStyle = 'rgba(143,160,190,0.6)';
+  const majorStartX = Math.floor(startX/12)*12;
+  for(let i=majorStartX;i<=endX;i+=12){
+    const [x] = toPx(i,0);
+    ctx.beginPath();
+    ctx.moveTo(x,0);
+    ctx.lineTo(x,cssH);
+    ctx.stroke();
+  }
+  const majorStartY = Math.floor(startY/12)*12;
+  for(let j=majorStartY;j<=endY;j+=12){
+    const [,y] = toPx(0,j);
+    ctx.beginPath();
+    ctx.moveTo(0,y);
+    ctx.lineTo(cssW,y);
+    ctx.stroke();
+  }
   ctx.restore();
 }
 function lineInches(x1In,y1In,x2In,y2In){ const [x1,y1]=toPx(x1In,y1In), [x2,y2]=toPx(x2In,y2In); ctx.beginPath(); ctx.moveTo(x1,y1); ctx.lineTo(x2,y2); ctx.stroke(); }
@@ -326,29 +473,144 @@ function drawSpacingGuide(c){
   ctx.fillText(`Stringer Spacing Guide — ${c.stringers} stringers across ${fmt(ASSUMED_STAIR_WIDTH_IN)}`, tx, ty); ctx.restore();
 }
 function drawStair(c){
+  if(!c) return;
   const run=c.treadDepthIn, rise=c.finishedRiserIn, over=c.nosingIn;
   clearCanvas();
-  ctx.save(); ctx.lineWidth=2; ctx.strokeStyle='#5fb3ff';
+  drawGrid();
+  ctx.save();
+  ctx.lineCap='round';
+  ctx.lineJoin='round';
+  ctx.lineWidth=2;
+  ctx.strokeStyle='#5fb3ff';
   let x=0, y=0;
   for(let i=0;i<c.treads;i++){
     lineInches(x, y, x+run, y);
-    ctx.strokeStyle='#7cd67c'; lineInches(x+run, y, x+run+over, y); ctx.strokeStyle='#5fb3ff';
-    if(!(c.topTread && i===c.treads-1)){ lineInches(x+run, y, x+run, y+rise); }
+    ctx.strokeStyle='#7cd67c';
+    lineInches(x+run, y, x+run+over, y);
+    ctx.strokeStyle='#5fb3ff';
+    if(!(c.topTread && i===c.treads-1)){
+      lineInches(x+run, y, x+run, y+rise);
+    }
     x+=run; y+=rise;
   }
-  if(!c.topTread){ lineInches(x, y, x, y + (c.risers ? rise : 0)); }
-  ctx.strokeStyle='#8ab6ff'; ctx.lineWidth=2.5; lineInches(0,0, c.totalRunCutIn, c.effectiveRiseIn);
+  if(!c.topTread){
+    lineInches(x, y, x, y + (c.risers ? rise : 0));
+  }
+  ctx.strokeStyle='#8ab6ff';
+  ctx.lineWidth=2.5;
+  lineInches(0,0, c.totalRunCutIn, c.effectiveRiseIn);
   drawFramingSquare(run, rise);
   labelDimMid(0,0, c.totalRunCutIn, 0, `Total Run (cut) ${fmt(c.totalRunCutIn)}`, '#7cd67c');
   labelDimMid(c.totalRunCutIn, 0, c.totalRunCutIn, c.effectiveRiseIn, `Effective Rise ${fmt(c.effectiveRiseIn)}`, '#ff9c9c');
   const [xa,ya]=toPx(c.totalRunCutIn,c.effectiveRiseIn), [xb,yb]=toPx(0,0);
   const mx=(xa+xb)/2, my=(ya+yb)/2;
-  ctx.strokeStyle='#8ad'; ctx.fillStyle='#c3d4ff'; ctx.lineWidth=1.25; ctx.setLineDash([6,6]);
-  ctx.beginPath(); ctx.moveTo(xb,yb); ctx.lineTo(xa,ya); ctx.stroke(); ctx.setLineDash([]);
-  ctx.font='12px system-ui'; ctx.textAlign='center'; ctx.textBaseline='bottom';
+  ctx.strokeStyle='#8ad';
+  ctx.fillStyle='#c3d4ff';
+  ctx.lineWidth=1.25;
+  ctx.setLineDash([6,6]);
+  ctx.beginPath();
+  ctx.moveTo(xb,yb);
+  ctx.lineTo(xa,ya);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.font='12px system-ui';
+  ctx.textAlign='center';
+  ctx.textBaseline='bottom';
   ctx.fillText(`Stringer ${fmt(c.stringerLenIn)}`, mx, my-8);
   drawSpacingGuide(c);
   ctx.restore();
+  updateScaleBadge();
+}
+
+const pointerState = new Map();
+let pinchStart = null;
+
+function applyPan(dx, dy){
+  if(!state.calc) return;
+  state.view.autoFit = false;
+  state.view.panX += dx;
+  state.view.panY += dy;
+  updateOrigin();
+  drawStair(state.calc);
+}
+
+function applyZoom(targetZoom, anchorX, anchorY){
+  if(!state.calc) return;
+  const newZoom = clamp(targetZoom, state.view.minZoom, state.view.maxZoom);
+  const [wx, wy] = screenToInches(anchorX, anchorY);
+  state.view.zoom = newZoom;
+  const scaled = state.view.baseScale * state.view.zoom;
+  state.view.scalePxPerIn = Math.max(1, scaled);
+  const newOx = anchorX - wx * state.view.scalePxPerIn;
+  const newOy = anchorY + wy * state.view.scalePxPerIn;
+  state.view.panX = newOx - state.view.baseOx;
+  state.view.panY = newOy - state.view.baseOy;
+  updateOrigin();
+  state.view.autoFit = false;
+  drawStair(state.calc);
+}
+
+function onPointerDown(e){
+  if(e.pointerType === 'mouse' && e.button !== 0) return;
+  e.preventDefault();
+  el.canvas.setPointerCapture(e.pointerId);
+  pointerState.set(e.pointerId, { clientX: e.clientX, clientY: e.clientY });
+  if(pointerState.size === 2){
+    const pts = Array.from(pointerState.values());
+    pinchStart = {
+      distance: Math.hypot(pts[0].clientX - pts[1].clientX, pts[0].clientY - pts[1].clientY),
+      zoom: state.view.zoom
+    };
+  }
+}
+
+function onPointerMove(e){
+  if(!pointerState.has(e.pointerId)) return;
+  if(e.pointerType === 'touch') e.preventDefault();
+  const prev = pointerState.get(e.pointerId);
+  const dx = e.clientX - prev.clientX;
+  const dy = e.clientY - prev.clientY;
+  pointerState.set(e.pointerId, { clientX: e.clientX, clientY: e.clientY });
+  if(pointerState.size === 1){
+    if(Math.abs(dx) > 0 || Math.abs(dy) > 0){ applyPan(dx, dy); }
+  } else if(pointerState.size === 2 && pinchStart){
+    const pts = Array.from(pointerState.values());
+    const distance = Math.hypot(pts[0].clientX - pts[1].clientX, pts[0].clientY - pts[1].clientY);
+    if(pinchStart.distance > 0){
+      const rect = el.canvas.getBoundingClientRect();
+      const centerX = (pts[0].clientX + pts[1].clientX)/2 - rect.left;
+      const centerY = (pts[0].clientY + pts[1].clientY)/2 - rect.top;
+      const scaleFactor = distance / pinchStart.distance;
+      applyZoom(pinchStart.zoom * scaleFactor, centerX, centerY);
+    }
+  }
+}
+
+function endPointer(e){
+  if(pointerState.has(e.pointerId)){
+    pointerState.delete(e.pointerId);
+  }
+  try { el.canvas.releasePointerCapture(e.pointerId); } catch(err){}
+  if(pointerState.size < 2){
+    pinchStart = null;
+  } else if(pointerState.size === 2){
+    const pts = Array.from(pointerState.values());
+    pinchStart = {
+      distance: Math.hypot(pts[0].clientX - pts[1].clientX, pts[0].clientY - pts[1].clientY),
+      zoom: state.view.zoom
+    };
+  }
+}
+
+function onWheel(e){
+  if(!state.calc) return;
+  e.preventDefault();
+  const rect = el.canvas.getBoundingClientRect();
+  const anchorX = e.clientX - rect.left;
+  const anchorY = e.clientY - rect.top;
+  const delta = e.deltaY;
+  const factor = Math.exp(-delta / 400);
+  applyZoom(state.view.zoom * factor, anchorX, anchorY);
 }
 
 /* Inputs */
@@ -385,13 +647,37 @@ function resetDefaults(){
   el.nosing.value = DEFAULTS.nosingIn;
   el.kerf.value = DEFAULTS.kerfIn;
   el.topTread.checked = DEFAULTS.topTread;
+  state.view.autoFit = true;
+  state.view.zoom = 1;
+  state.view.panX = 0;
+  state.view.panY = 0;
   update();
 }
-function fitView(){ computeScale(state.calc); update(); }
+function fitView(){
+  if(!state.calc) return;
+  state.view.autoFit = true;
+  state.view.zoom = 1;
+  state.view.panX = 0;
+  state.view.panY = 0;
+  computeScale(state.calc);
+  drawStair(state.calc);
+}
 
 ['input','change'].forEach(evt=> el.form.addEventListener(evt, update, {passive:true}));
 el.fitBtn.addEventListener('click', fitView);
 el.resetBtn.addEventListener('click', resetDefaults);
+el.canvas.addEventListener('pointerdown', onPointerDown);
+el.canvas.addEventListener('pointermove', onPointerMove);
+el.canvas.addEventListener('pointerup', endPointer);
+el.canvas.addEventListener('pointerleave', endPointer);
+el.canvas.addEventListener('pointercancel', endPointer);
+el.canvas.addEventListener('wheel', onWheel, { passive:false });
+el.canvas.addEventListener('dblclick', ()=>fitView());
+window.addEventListener('resize', handleResize);
+if(typeof ResizeObserver !== 'undefined'){
+  const ro = new ResizeObserver(()=>handleResize());
+  ro.observe(el.blueprint);
+}
 
 /* PDF Export */
 function exportPDF(){
@@ -412,8 +698,22 @@ function exportPDF(){
     <div class="section">${cutHTML}</div>
     <script>setTimeout(()=>window.print(),300);<\/script>
   </body></html>`;
-  const w = window.open('', '_blank', 'noopener,noreferrer');
-  w.document.open(); w.document.write(html); w.document.close();
+  const blob = new Blob([html], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  const w = window.open(url, '_blank', 'noopener');
+  const revoke = () => URL.revokeObjectURL(url);
+  if(!w){
+    const link = document.createElement('a');
+    link.href = url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setTimeout(revoke, 4000);
+  } else {
+    w.onload = () => setTimeout(revoke, 2000);
+  }
 }
 el.pdfBtn.addEventListener('click', exportPDF);
 
@@ -425,6 +725,8 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+resizeCanvas();
+updateScaleBadge();
 resetDefaults();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- restyle the stair profile panel with a responsive blueprint container, overlay hints, and a cleaner legend
- make the canvas resize-aware with pan, pinch/scroll zoom, scale badges, and redraw logic for a smoother mobile experience
- fix PDF export by streaming the generated markup through a Blob URL to avoid blocked about:blank popups

## Testing
- `node tests/computeStair.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ceaef6ccb0832ba1010af11f1b7b4a